### PR TITLE
feat(S3 IAM): Deny non-TLS requests to S3 bucket

### DIFF
--- a/bucket.tf
+++ b/bucket.tf
@@ -75,6 +75,29 @@ data "aws_iam_policy_document" "bucket" {
       ]
     }
   }
+
+  statement {
+    sid    = "DenyNonSSLRequests"
+    effect = "Deny"
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    actions = ["s3:*"]
+
+    resources = [
+      aws_s3_bucket.this.arn,
+      format("%s/*", aws_s3_bucket.this.arn),
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
 }
 
 resource "aws_s3_bucket_policy" "this" {


### PR DESCRIPTION
- Adds an additional statement to the S3 bucket IAM policy which denies requests with `aws:secureTransport = False`
- This blocks traffic that **does not** use TLS
- This is recommended by AWS (see the "Enforce encryption of data in transit" section [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/security-best-practices.html#security-best-practices-prevent))
- This should have no to very little impact, as any requests being made using AWS tools (CLI, SDK, console etc.) will be secured by TLS. Only custom tooling that does not use TLS would be impacted.