### PR TITLE
feat(s3): add additional_policy_statements and enforce_secure_defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,10 @@ All fields in each statement object are required. Use `sid = ""` if you don't ne
 
 ### Hardening deny statements
 
-Set `enforce_secure_defaults = true` to add pre-built hardening deny statements to the policy. Currently includes:
+Set `enforce_secure_defaults = true` to add pre-built hardening to the bucket. Currently includes:
 
-- `DenyNonSSLRequests` — denies all S3 actions over non-HTTPS connections
+- `DenyNonSSLRequests` — denies all S3 actions over non-HTTPS connections (bucket policy)
+- Public access block — enables all four settings (`block_public_acls`, `block_public_policy`, `ignore_public_acls`, `restrict_public_buckets`)
 
 **This variable defaults to `false` for backward compatibility. It will default to `true` in a future major release.** Teams are encouraged to opt in now.
 
@@ -146,6 +147,7 @@ No modules.
 | [aws_s3_bucket_lifecycle_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_replication_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_replication_configuration) | resource |
+| [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_versioning.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -163,7 +165,7 @@ No modules.
 | <a name="input_destination_account_id"></a> [destination\_account\_id](#input\_destination\_account\_id) | The account ID of the destination S3 bucket where reports will be replicated to. This will be provided as part of the onboarding process. | `string` | n/a | yes |
 | <a name="input_destination_bucket_name"></a> [destination\_bucket\_name](#input\_destination\_bucket\_name) | The name of the destination S3 bucket where reports will be replicated to. This will be provided as part of the onboarding process. | `string` | n/a | yes |
 | <a name="input_enable_carbon_export"></a> [enable\_carbon\_export](#input\_enable\_carbon\_export) | Enables the collection of carbon footprint report | `bool` | `true` | no |
-| <a name="input_enforce_secure_defaults"></a> [enforce\_secure\_defaults](#input\_enforce\_secure\_defaults) | When true, adds hardening deny statements to the bucket policy (e.g. DenyNonSSLRequests). Defaults to false for backward compatibility. Will default to true in a future major release. | `bool` | `false` | no |
+| <a name="input_enforce_secure_defaults"></a> [enforce\_secure\_defaults](#input\_enforce\_secure\_defaults) | When true, adds hardening to the bucket: denies non-SSL requests via bucket policy and enables all four public access block settings. Defaults to false for backward compatibility. Will default to true in a future major release. | `bool` | `false` | no |
 | <a name="input_enable_cost_recommendations_export"></a> [enable\_cost\_recommendations\_export](#input\_enable\_cost\_recommendations\_export) | Enables the collection of cost recommendations report | `bool` | `true` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to all resources created by this module. | `map(string)` | `{}` | no |
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,84 @@ The Bucket's Role has permissions to replicate any Object that is put in it, so 
 
 If this library is deployed through a continuous deployment (CD) pipeline, deploying teams should thoroughly check any changes to this codebase before they are deployed. 
 
+## Bucket Policy
+
+The module creates an S3 bucket policy that grants the BCM Data Exports service the permissions it needs to write report data. This policy is always present and cannot be removed.
+
+### Default behaviour
+
+By default, the module applies only the BCM grant. Upgrading to a new version of the module will not change this policy — existing deployments see no Terraform plan changes.
+
+### Recommended: adding statements via the module
+
+Use `additional_policy_statements` to add your own IAM statements on top of the default BCM grant. This is the recommended approach — it avoids creating a second `aws_s3_bucket_policy` resource that would conflict with the module's own.
+
+Example — adding `DenyNonSSLRequests`:
+
+```hcl
+module "focus" {
+  source = "github.com/co-cddo/terraform-aws-focus?ref=..."
+
+  destination_account_id  = var.cddo_destination_account_id
+  destination_bucket_name = var.cddo_destination_bucket_name
+
+  additional_policy_statements = [
+    {
+      sid       = "DenyNonSSLRequests"
+      effect    = "Deny"
+      actions   = ["s3:*"]
+      resources = [
+        "arn:aws:s3:::my-bucket",
+        "arn:aws:s3:::my-bucket/*",
+      ]
+      principals = {
+        type        = "*"
+        identifiers = ["*"]
+      }
+      conditions = [
+        {
+          test     = "Bool"
+          variable = "aws:SecureTransport"
+          values   = ["false"]
+        }
+      ]
+    }
+  ]
+}
+```
+
+All fields in each statement object are required. Use `sid = ""` if you don't need a statement ID, and `conditions = []` if you have no conditions.
+
+> **Note:** Invalid ARNs in `resources` or `principals.identifiers` will not cause `terraform plan` to fail — they will be rejected by AWS at `terraform apply` time.
+
+### Hardening deny statements
+
+Set `enforce_secure_defaults = true` to add pre-built hardening deny statements to the policy. Currently includes:
+
+- `DenyNonSSLRequests` — denies all S3 actions over non-HTTPS connections
+
+**This variable defaults to `false` for backward compatibility. It will default to `true` in a future major release.** Teams are encouraged to opt in now.
+
+```hcl
+module "focus" {
+  source = "github.com/co-cddo/terraform-aws-focus?ref=..."
+
+  destination_account_id  = var.cddo_destination_account_id
+  destination_bucket_name = var.cddo_destination_bucket_name
+
+  enforce_secure_defaults = true
+}
+```
+
+### Legacy: external `aws_s3_bucket_policy` resource
+
+If you currently manage your own `aws_s3_bucket_policy` resource targeting the module's bucket, this continues to work. However, Terraform will conflict if both your resource and the module attempt to manage the same bucket policy. To migrate to the recommended approach:
+
+1. Move your custom statements into `additional_policy_statements` on the module
+2. Remove your external `aws_s3_bucket_policy` resource from your configuration
+3. Run `terraform state rm aws_s3_bucket_policy.<your_resource_name>` to remove it from state
+4. Run `terraform plan` — you should see the policy updated in-place with no destruction
+
 ## Features
 
 * Creates AWS Billing & Cost Management data exports for FOCUS, Carbon Emission and Cost Optimisation.
@@ -78,12 +156,14 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_additional_policy_statements"></a> [additional\_policy\_statements](#input\_additional\_policy\_statements) | Additional IAM policy statements to include in the S3 bucket policy. All fields are required. Statements are appended to the default BCM grant and cannot replace or remove it. | `list(object(...))` | `[]` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | The name of the S3 bucket to be created to store reports before replication. If omitted it will create one for you. | `string` | `null` | no |
 | <a name="input_bucket_tags"></a> [bucket\_tags](#input\_bucket\_tags) | Map of tags to be associated with the reporting bucket | `map(string)` | `{}` | no |
 | <a name="input_create_cost_recommendations_service_linked_role"></a> [create\_cost\_recommendations\_service\_linked\_role](#input\_create\_cost\_recommendations\_service\_linked\_role) | Enables the creation of the required service-linked role for data exports to access cost optimisation hub | `bool` | `false` | no |
 | <a name="input_destination_account_id"></a> [destination\_account\_id](#input\_destination\_account\_id) | The account ID of the destination S3 bucket where reports will be replicated to. This will be provided as part of the onboarding process. | `string` | n/a | yes |
 | <a name="input_destination_bucket_name"></a> [destination\_bucket\_name](#input\_destination\_bucket\_name) | The name of the destination S3 bucket where reports will be replicated to. This will be provided as part of the onboarding process. | `string` | n/a | yes |
 | <a name="input_enable_carbon_export"></a> [enable\_carbon\_export](#input\_enable\_carbon\_export) | Enables the collection of carbon footprint report | `bool` | `true` | no |
+| <a name="input_enforce_secure_defaults"></a> [enforce\_secure\_defaults](#input\_enforce\_secure\_defaults) | When true, adds hardening deny statements to the bucket policy (e.g. DenyNonSSLRequests). Defaults to false for backward compatibility. Will default to true in a future major release. | `bool` | `false` | no |
 | <a name="input_enable_cost_recommendations_export"></a> [enable\_cost\_recommendations\_export](#input\_enable\_cost\_recommendations\_export) | Enables the collection of cost recommendations report | `bool` | `true` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to all resources created by this module. | `map(string)` | `{}` | no |
 

--- a/bucket.tf
+++ b/bucket.tf
@@ -75,6 +75,56 @@ data "aws_iam_policy_document" "bucket" {
       ]
     }
   }
+
+  dynamic "statement" {
+    for_each = var.additional_policy_statements
+
+    content {
+      sid       = statement.value.sid
+      effect    = statement.value.effect
+      actions   = statement.value.actions
+      resources = statement.value.resources
+
+      principals {
+        type        = statement.value.principals.type
+        identifiers = statement.value.principals.identifiers
+      }
+
+      dynamic "condition" {
+        for_each = statement.value.conditions
+        content {
+          test     = condition.value.test
+          variable = condition.value.variable
+          values   = condition.value.values
+        }
+      }
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.enforce_secure_defaults ? [1] : []
+
+    content {
+      sid     = "DenyNonSSLRequests"
+      effect  = "Deny"
+      actions = ["s3:*"]
+      resources = [
+        aws_s3_bucket.this.arn,
+        format("%s/*", aws_s3_bucket.this.arn),
+      ]
+
+      principals {
+        type        = "*"
+        identifiers = ["*"]
+      }
+
+      condition {
+        test     = "Bool"
+        variable = "aws:SecureTransport"
+        values   = ["false"]
+      }
+    }
+  }
 }
 
 resource "aws_s3_bucket_policy" "this" {

--- a/bucket.tf
+++ b/bucket.tf
@@ -132,6 +132,17 @@ resource "aws_s3_bucket_policy" "this" {
   policy = data.aws_iam_policy_document.bucket.json
 }
 
+resource "aws_s3_bucket_public_access_block" "this" {
+  count = var.enforce_secure_defaults ? 1 : 0
+
+  bucket = aws_s3_bucket.this.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 resource "aws_s3_bucket_replication_configuration" "this" {
   bucket = aws_s3_bucket.this.id
   role   = aws_iam_role.this.arn

--- a/providers.tf
+++ b/providers.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 0.13"
+
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/variables.tf
+++ b/variables.tf
@@ -43,3 +43,29 @@ variable "tags" {
   default     = {}
   description = "Tags to apply to all resources created by this module."
 }
+
+variable "additional_policy_statements" {
+  type = list(object({
+    sid       = string
+    effect    = string
+    actions   = list(string)
+    resources = list(string)
+    principals = object({
+      type        = string
+      identifiers = list(string)
+    })
+    conditions = list(object({
+      test     = string
+      variable = string
+      values   = list(string)
+    }))
+  }))
+  default     = []
+  description = "Additional IAM policy statements to include in the S3 bucket policy. All fields are required — use empty string for sid if not needed, empty list for conditions if none required. Statements are appended to the default BCM grant and cannot replace or remove it. Use this instead of creating a separate aws_s3_bucket_policy resource."
+}
+
+variable "enforce_secure_defaults" {
+  type        = bool
+  default     = false
+  description = "When true, adds hardening deny statements to the bucket policy (e.g. DenyNonSSLRequests). Defaults to false for backward compatibility. Will default to true in a future major release."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -67,5 +67,5 @@ variable "additional_policy_statements" {
 variable "enforce_secure_defaults" {
   type        = bool
   default     = false
-  description = "When true, adds hardening deny statements to the bucket policy (e.g. DenyNonSSLRequests). Defaults to false for backward compatibility. Will default to true in a future major release."
+  description = "When true, adds hardening to the bucket: denies non-SSL requests via bucket policy and enables all four public access block settings. Defaults to false for backward compatibility. Will default to true in a future major release."
 }


### PR DESCRIPTION
## Add secure default S3 bucket policy with targeted override capability

**Jira Issue:** [OB-404](https://gds-digital-transformation.atlassian.net/browse/OB-404)

---

### Implementation Summary

- Added `additional_policy_statements` variable — consumers append IAM statement objects to the bucket policy without replacing the BCM grant or creating a competing `aws_s3_bucket_policy` resource
- Added `enforce_secure_defaults` variable — when `true`, adds `DenyNonSSLRequests` deny statement and enables all four public access block settings; defaults to `false` for zero-diff upgrade; will default to `true` in a future major release
- Extended `data.aws_iam_policy_document.bucket` with two dynamic `statement` blocks — additive only, BCM grant hardcoded
- Added `aws_s3_bucket_public_access_block` resource gated on `enforce_secure_defaults`
- Added `required_version = ">= 0.13"` to `providers.tf` — makes the existing implicit floor explicit
- Updated `README.md` with Bucket Policy section covering recommended path, hardening flag, and legacy migration steps

### Test Coverage

- `terraform validate` — confirms schema and all references valid
- `terraform fmt --check` — formatting clean

---

### Key Design Decisions

- Zero-diff upgrade: both new variables default to inactive (`false` / `[]`) — existing consumers see no plan changes
- All fields in `additional_policy_statements` objects are required (no `optional()`) — compatible with Terraform ≥ 0.13
- `enforce_secure_defaults` is opt-in now, opt-out at next major version — clear semver-signalled migration path
- BCM grant statement is hardcoded — structurally impossible to remove via either variable

### Acceptance Criteria Coverage

| AC# | Description | Implemented by |
|-----|-------------|----------------|
| AC1 | Module upgrade produces no plan changes for existing consumers | Both variables default to inactive |
| AC2 | Consumer can add a policy statement without replacing the default | `additional_policy_statements` dynamic block |
| AC3 | Default statements cannot be removed via the new override mechanism | BCM grant hardcoded; dynamic blocks append only |
| AC4 | Existing full policy override continues to work | No change to existing resources |
| AC5 | Documentation distinguishes recommended and legacy paths | README Bucket Policy section |